### PR TITLE
Remove version input field from book form

### DIFF
--- a/frontend/src/pages/Add.jsx
+++ b/frontend/src/pages/Add.jsx
@@ -36,7 +36,7 @@ console.log(book)
    <input type="number" placeholder="price" onChange={handleChange} name="price"/>
    <input type="text" placeholder="cover" onChange={handleChange} name="cover"/>
    <input type="text" placeholder="writer" onChange={handleChange} name="writer"/>
-   <input type="text" placeholder="version" onChange={handleChange} name="version"/>
+   {/* <input type="text" placeholder="version" onChange={handleChange} name="version"/> */}
    <button onClick={handleClick} className='addButton'>
     Add
    </button>


### PR DESCRIPTION
## Code Refactoring

### Description
Commented out the version input field in the Add.jsx form component to temporarily disable the version field functionality.

### Motivation
The version input field was likely causing issues or is not currently needed in the book adding workflow. Commenting it out rather than completely removing it preserves the code for potential future re-enablement.

### Changes
- Commented out the version input field line in `frontend/src/pages/Add.jsx:38`
- Preserved the input field structure using JSX comment syntax
- No other form functionality affected

### Testing
- [ ] All existing tests pass
- [ ] No functional changes to other form fields
- [ ] Performance impact assessed

### Risk Assessment
Low risk change. The modification only affects the version input field display and does not impact:
- Other form fields (writer, description, price, cover)
- Form submission logic
- Data handling or validation
- Backend integration

The field can be easily re-enabled by uncommenting the line if needed in the future.